### PR TITLE
Don't swallow LSP errors in zk.api

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ You can use it to write your own specialized functions for interacting with `zk`
 ---@param options? table additional options
 ---@param cb function callback function
 ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zkindex
-require("zk").api.index(path, options, function(stats)
+require("zk").api.index(path, options, function(err, stats)
   -- do something with the stats
 end)
 ```
@@ -301,7 +301,7 @@ end)
 ---@param options? table additional options
 ---@param cb function callback function
 ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
-require("zk").api.new(path, options, function(res)
+require("zk").api.new(path, options, function(err, res)
   file_path = res.path
   -- do something with the new file path
 end)
@@ -312,7 +312,7 @@ end)
 ---@param options table additional options
 ---@param cb function callback function
 ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zklist
-require("zk").api.list(path, options, function(notes)
+require("zk").api.list(path, options, function(err, notes)
   -- do something with the notes
 end)
 ```
@@ -322,7 +322,7 @@ end)
 ---@param options? table additional options
 ---@param cb function callback function
 ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zktaglist
-require("zk").api.tag.list(path, options, function(tags)
+require("zk").api.tag.list(path, options, function(err, tags)
   -- do something with the tags
 end)
 ```

--- a/doc/zk.txt
+++ b/doc/zk.txt
@@ -301,7 +301,7 @@ You can use it to write your own specialized functions for interacting with `zk`
     ---@param options? table additional options
     ---@param cb function callback function
     ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zkindex
-    require("zk").api.index(path, options, function(stats)
+    require("zk").api.index(path, options, function(err, stats)
       -- do something with the stats
     end)
 <
@@ -310,7 +310,7 @@ You can use it to write your own specialized functions for interacting with `zk`
     ---@param options? table additional options
     ---@param cb function callback function
     ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
-    require("zk").api.new(path, options, function(res)
+    require("zk").api.new(path, options, function(err, res)
       file_path = res.path
       -- do something with the new file path
     end)
@@ -320,7 +320,7 @@ You can use it to write your own specialized functions for interacting with `zk`
     ---@param options table additional options
     ---@param cb function callback function
     ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zklist
-    require("zk").api.list(path, options, function(notes)
+    require("zk").api.list(path, options, function(err, notes)
       -- do something with the notes
     end)
 <
@@ -329,7 +329,7 @@ You can use it to write your own specialized functions for interacting with `zk`
     ---@param options? table additional options
     ---@param cb function callback function
     ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zktaglist
-    require("zk").api.tag.list(path, options, function(tags)
+    require("zk").api.tag.list(path, options, function(err, tags)
       -- do something with the tags
     end)
 <

--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -64,7 +64,8 @@ end
 ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
 function M.new(options)
   options = options or {}
-  api.new(options.notebook_path, options, function(res)
+  api.new(options.notebook_path, options, function(err, res)
+    assert(not err, tostring(err))
     if options and options.edit == false then
       return
     end
@@ -79,7 +80,8 @@ end
 ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zkindex
 function M.index(options)
   options = options or {}
-  api.index(options.notebook_path, options, function(stats)
+  api.index(options.notebook_path, options, function(err, stats)
+    assert(not err, tostring(err))
     vim.notify(vim.inspect(stats))
   end)
 end
@@ -93,7 +95,8 @@ end
 ---@see zk.ui.pick_notes
 function M.pick_notes(options, picker_options, cb)
   options = vim.tbl_extend("force", { select = ui.get_pick_notes_list_api_selection(picker_options) }, options or {})
-  api.list(options.notebook_path, options, function(notes)
+  api.list(options.notebook_path, options, function(err, notes)
+    assert(not err, tostring(err))
     ui.pick_notes(notes, picker_options, cb)
   end)
 end
@@ -107,7 +110,8 @@ end
 ---@see zk.ui.pick_tags
 function M.pick_tags(options, picker_options, cb)
   options = options or {}
-  api.tag.list(options.notebook_path, options, function(tags)
+  api.tag.list(options.notebook_path, options, function(err, tags)
+    assert(not err, tostring(err))
     ui.pick_tags(tags, picker_options, cb)
   end)
 end

--- a/lua/zk/api.lua
+++ b/lua/zk/api.lua
@@ -22,12 +22,7 @@ local function execute_command(cmd, path, options, cb)
       path or util.resolve_notebook_path(bufnr),
       options,
     },
-  }, function(err, res)
-    assert(not err, tostring(err))
-    if res and cb then
-      cb(res)
-    end
-  end, bufnr)
+  }, cb, bufnr)
 end
 
 ---@param path? string path to explicitly specify the notebook


### PR DESCRIPTION
Errors can for example happen when no `zk` notebook root is found. The `zk.api` level is the wrong place to consume these errors.