### PR TITLE
fzf: fix jumping to note with spaces in filename

### DIFF
--- a/lua/zk/pickers/fzf.lua
+++ b/lua/zk/pickers/fzf.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local delimiter = "\x01 "
+local delimiter = "\x01"
 
 -- we want can't do vim.fn["fzf#wrap"] because the sink/sinklist funcrefs
 -- are reset to vim.NIL when they are converted to Lua


### PR DESCRIPTION
The space of `delimiter` in `fzf.lua` cause note with spaces in filename
not openable.

Picker: `fzf`

Example note (zsh.config - vi mode.md):

```
  # zsh.config - vi mode

  note body...
```