### PR TITLE
fix tag name selection in fzf

### DIFF
--- a/lua/zk/pickers/fzf.lua
+++ b/lua/zk/pickers/fzf.lua
@@ -70,7 +70,7 @@ function M.show_tag_picker(tags, options, cb)
         tags_by_name[tag.name] = tag
       end
       local selected_tags = vim.tbl_map(function(line)
-        local name = string.match(line, "([^" .. delimiter .. "]+)", 2)
+        local name = string.match(line, "%d+%s+" .. delimiter .. "(.+)")
         return tags_by_name[name]
       end, lines)
       if options.multi_select then


### PR DESCRIPTION
In tag list in `fzf` the line format is `notes_count delimiter tag_name` (e. g. `3 sometag`). Incorrect regexp is used for parsing tag name from the selected line. It causes that the selected tag is empty and notes are not filtered by tag in the following notes list. This pull request should fix it.  