### PR TITLE
Lazily load note contents in Telescope

### DIFF
--- a/lua/zk/pickers/telescope.lua
+++ b/lua/zk/pickers/telescope.lua
@@ -10,7 +10,7 @@ local previewers = require("telescope.previewers")
 
 local M = {}
 
-M.note_picker_list_api_selection = { "title", "absPath", "path", "rawContent" }
+M.note_picker_list_api_selection = { "title", "absPath", "path" }
 
 function M.create_note_entry_maker(_)
   return function(note)
@@ -50,9 +50,11 @@ end
 function M.make_note_previewer()
   return previewers.new_buffer_previewer({
     define_preview = function(self, entry)
-      lines = vim.split(entry.value.rawContent or "", "\n")
-      vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
-      putils.highlighter(self.state.bufnr, "markdown")
+      conf.buffer_previewer_maker(
+        entry.value.absPath,
+        self.state.bufnr,
+        { bufname = entry.value.title or entry.value.path }
+      )
     end,
   })
 end


### PR DESCRIPTION
What are your thoughts on this "optimization"?

Prior to this change, the `rawContents` of **all** notes were loaded via the LSP connection.  When the quantity of notes is large (30k), this results in more memory utilization as well as slower transfer times from the LSP server, which ultimately delays the opening of Telescope.

With this change, `rawContents` is no longer requested from the LSP server--only `title`, `absPath`, and `path` are loaded for each note. To generate previews, we use the "absPath" to open the file via the `buffer_previewer_maker` when Telescope needs to show a preview.

I tested the performance of this against 30,000 random notes of lorem ipsum with a median size of 1,464 bytes.  Memory utilization is much lower and the time to open the Telescope window is roughly twice as fast on my computer.