### PR TITLE
Allow to inline new notes in the current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Try out different [commands](#built-in-commands) such as `:ZkNotes` or `:ZkNew`,
 
 ```vim
 " Creates and edits a new note
+"
+" Use the `inline = true` option to insert the content of the created note at the caret position, instead of writing the note on the file system.
+"
 " params
 "   (optional) additional options, see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
 :ZkNew [{options}]
@@ -94,6 +97,9 @@ Try out different [commands](#built-in-commands) such as `:ZkNotes` or `:ZkNew`,
 
 ```vim
 " Creates a new note and uses the last visual selection as the title while replacing the selection with a link to the new note
+"
+" Use the `inline = true` option to replace the selection with the content of the created note, instead of writing the note on the file system.
+"
 " params
 "   (optional) additional options, see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
 :'<,'>ZkNewFromTitleSelection [{options}]
@@ -101,6 +107,9 @@ Try out different [commands](#built-in-commands) such as `:ZkNotes` or `:ZkNew`,
 
 ```vim
 " Creates a new note and uses the last visual selection as the content while replacing the selection with a link to the new note
+"
+" Use the `inline = true` option to replace the selection with the content of the created note, instead of writing the note on the file system.
+"
 " params
 "   (optional) additional options, see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
 :'<,'>ZkNewFromContentSelection [{options}]

--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -66,11 +66,10 @@ function M.new(options)
   options = options or {}
   api.new(options.notebook_path, options, function(err, res)
     assert(not err, tostring(err))
-    if options and options.edit == false then
-      return
+    if options and options.dryRun ~= true and options.edit ~= false then
+        -- neovim does not yet support window/showDocument, therefore we handle options.edit locally
+        vim.cmd("edit " .. res.path)
     end
-    -- neovim does not yet support window/showDocument, therefore we handle options.edit locally
-    vim.cmd("edit " .. res.path)
   end)
 end
 

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -4,20 +4,54 @@ local commands = require("zk.commands")
 
 commands.add("ZkIndex", zk.index)
 
-commands.add("ZkNew", zk.new)
+commands.add("ZkNew", function(options)
+  options = options or {}
+
+  if options.inline == true then
+    options.inline = nil
+    options.dryRun = true
+    options.insertContentAtLocation = util.get_lsp_location_from_caret()
+  end
+
+  zk.new(options)
+end)
 
 commands.add("ZkNewFromTitleSelection", function(options)
   local location = util.get_lsp_location_from_selection()
   local selected_text = util.get_text_in_range(location.range)
   assert(selected_text ~= nil, "No selected text")
-  zk.new(vim.tbl_extend("force", { insertLinkAtLocation = location, title = selected_text }, options or {}))
+
+  options = options or {}
+  options.title = selected_text
+
+  if options.inline == true then
+    options.inline = nil
+    options.dryRun = true
+    options.insertContentAtLocation = location
+  else
+    options.insertLinkAtLocation = location
+  end
+
+  zk.new(options)
 end, { needs_selection = true })
 
 commands.add("ZkNewFromContentSelection", function(options)
   local location = util.get_lsp_location_from_selection()
   local selected_text = util.get_text_in_range(location.range)
   assert(selected_text ~= nil, "No selected text")
-  zk.new(vim.tbl_extend("force", { insertLinkAtLocation = location, content = selected_text }, options or {}))
+
+  options = options or {}
+  options.content = selected_text
+
+  if options.inline == true then
+    options.inline = nil
+    options.dryRun = true
+    options.insertContentAtLocation = location
+  else
+    options.insertLinkAtLocation = location
+  end
+
+  zk.new(options)
 end, { needs_selection = true })
 
 commands.add("ZkCd", zk.cd)

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -45,10 +45,28 @@ end
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#location
 function M.get_lsp_location_from_selection()
   local params = vim.lsp.util.make_given_range_params()
-  params.uri = params.textDocument.uri
-  params.textDocument = nil
-  params.range = M.get_selected_range() -- workaround for neovim 0.6.1 bug (https://github.com/mickael-menu/zk-nvim/issues/19)
-  return params
+  return {
+    uri = params.textDocument.uri,
+    range = M.get_selected_range() -- workaround for neovim 0.6.1 bug (https://github.com/mickael-menu/zk-nvim/issues/19)
+  }
+end
+
+---Makes an LSP location object from the caret position in the current buffer.
+--
+---@return table LSP location object
+---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#location
+function M.get_lsp_location_from_caret()
+  local params = vim.lsp.util.make_given_range_params()
+
+  local row,col = unpack(vim.api.nvim_win_get_cursor(0))
+  local position = { line = row, character = col }
+  return {
+    uri = params.textDocument.uri,
+    range = {
+      start = position,
+      ["end"] = position
+    }
+  }
 end
 
 ---Gets the text in the given range of the current buffer.


### PR DESCRIPTION
Add a new `inline = true` option to `ZkNew`, `ZkNewFromTitleSelection` and `ZkNewFromContentSelection` to insert the generated note content at the caret position, instead of writing the new note to the file system.

Under the hood, it uses the new `zk.new` options `dryRun` and `insertContentAtLocation` from https://github.com/mickael-menu/zk/pull/276.