### PR TITLE
add option to insert link from telescope

### DIFF
--- a/lua/zk/config.lua
+++ b/lua/zk/config.lua
@@ -12,6 +12,9 @@ M.defaults = {
       filetypes = { "markdown" },
     },
   },
+  mappings = {
+    telescope_link_note = { {"i", "n"}, "<C-Y>" }
+  }
 }
 
 M.options = M.defaults -- not necessary, but better code completion

--- a/lua/zk/pickers/telescope.lua
+++ b/lua/zk/pickers/telescope.lua
@@ -7,6 +7,7 @@ local action_utils = require("telescope.actions.utils")
 local putils = require("telescope.previewers.utils")
 local entry_display = require("telescope.pickers.entry_display")
 local previewers = require("telescope.previewers")
+local config = require("zk.config")
 
 local M = {}
 
@@ -59,9 +60,28 @@ function M.make_note_previewer()
   })
 end
 
+function M.capture_cursor_state()
+  local pos = vim.api.nvim_win_get_cursor(0)
+  return {
+    bufnr = vim.api.nvim_get_current_buf(),
+    row = pos[1] - 1,
+    col = pos[2],
+  }
+end
+
+function M.insert_links_at_cursor(cursor, entries)
+  for i, entry in pairs(entries) do
+    entries[i] = string.format("[%s](%s)", entry.title, entry.path)
+  end
+  vim.api.nvim_buf_set_text(cursor.bufnr, cursor.row, cursor.col, cursor.row, cursor.col, entries)
+end
+
 function M.show_note_picker(notes, options, cb)
   options = options or {}
   local telescope_options = vim.tbl_extend("force", { prompt_title = options.title }, options.telescope or {})
+
+  -- before telescope buffer takes over
+  local cursor = M.capture_cursor_state()
 
   pickers.new(telescope_options, {
     finder = finders.new_table({
@@ -70,7 +90,7 @@ function M.show_note_picker(notes, options, cb)
     }),
     sorter = conf.file_sorter(options),
     previewer = M.make_note_previewer(),
-    attach_mappings = function(prompt_bufnr)
+    attach_mappings = function(prompt_bufnr, map)
       actions.select_default:replace(function()
         if options.multi_select then
           local selection = {}
@@ -87,6 +107,27 @@ function M.show_note_picker(notes, options, cb)
           cb(action_state.get_selected_entry().value)
         end
       end)
+
+
+      -- add the option to insert the note as link in current buffer
+      local mode = config.options.mappings.telescope_link_note[1]
+      local key = config.options.mappings.telescope_link_note[2]
+      map(mode, key, function()
+        local selection = {}
+        if options.multi_select then
+          action_utils.map_selections(prompt_bufnr, function(entry, _)
+            table.insert(selection, entry.value)
+          end)
+        else
+          selection = { action_state.get_selected_entry().value }
+        end
+        if vim.tbl_isempty(selection) then
+          selection = { action_state.get_selected_entry().value }
+        end
+        M.insert_links_at_cursor(cursor, selection)
+        actions.close(prompt_bufnr)
+      end)
+
       return true
     end,
   }):find()


### PR DESCRIPTION
Hello,

This lets you select notes in telescope and add them as links in the current buffer.

This is already part of my workflow personally, I thought it might be useful to include in the plugin. This works fine _but I don't think the PR should be accepted in its current form_. 

There might be a better way to configure the mapping. And as it stands, this inserts links as a markdown link. It should probably autodetect the desired format from a notebook's config. We could probably read the notebook config and use a pattern search to get the `link-format`. It's straightforward if it's either markdown or wiki links, but it's more involved if it's custom. Perhaps this is functionality that should be implemented in zk and exposed through the LSP? 

