### PR TITLE
Add support for 'zk.link' and some example linking commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ Try out different [commands](#built-in-commands) such as `:ZkNotes` or `:ZkNew`,
 " params
 "   (optional) additional options, see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zklist
 "   One additional option is `matchSelected` (boolean) which is only applicable to inserting a link around selected text. If `true`, the note picker will search for notes similar to the selected text. Otherwise, the note picker will load all notes to filter through.
-"    e.g. :'<'>ZkInsertLink {matchSelected = true}
-:ZkInsertLink [{options}]
-:'<,'>ZkInsertLink [{options}]
+"    e.g. :'<'>ZkInsertLinkAtSelection {matchSelected = true}
+:ZkInsertLink 
+:'<,'>ZkInsertLinkAtSelection [{options}]
 ```
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ Try out different [commands](#built-in-commands) such as `:ZkNotes` or `:ZkNew`,
 ```
 
 ```vim
+" Inserts a link at the cursor location or around the selected text.
+" params
+"   (optional) additional options, see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zklist
+"   One additional option is `matchSelected` (boolean) which is only applicable to inserting a link around selected text. If `true`, the note picker will search for notes similar to the selected text. Otherwise, the note picker will load all notes to filter through.
+"    e.g. :'<'>ZkInsertLink {matchSelected = true}
+:ZkInsertLink [{options}]
+:'<,'>ZkInsertLink [{options}]
+```
+
+```vim
 " Opens a notes picker, filters for notes that match the text in the last visual selection
 " params
 "   (optional) additional options, see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zklist

--- a/lua/zk/api.lua
+++ b/lua/zk/api.lua
@@ -41,6 +41,15 @@ function M.new(path, options, cb)
   execute_command("new", path, options, cb)
 end
 
+---@param target string path to note you want to link to
+---@param location string LSP location at current caret
+---@param path? string path to explicitly specify the notebook
+---@param cb? function callback function
+---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
+function M.link(target, location, path, cb)
+  execute_command("link", path, {path = target, location = location}, cb)
+end
+
 ---@param path? string path to explicitly specify the notebook
 ---@param options table additional options
 ---@param cb function callback function

--- a/lua/zk/api.lua
+++ b/lua/zk/api.lua
@@ -46,7 +46,7 @@ end
 ---@param path? string path to explicitly specify the notebook
 ---@param options? table Extra options; table in form {title: string}
 ---@param cb? function callback function
----@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
+---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zklink
 function M.link(target, location, path, options, cb)
   options = vim.tbl_extend("force", { path = target, location = location }, options or {})
 

--- a/lua/zk/api.lua
+++ b/lua/zk/api.lua
@@ -42,12 +42,15 @@ function M.new(path, options, cb)
 end
 
 ---@param target string path to note you want to link to
----@param location string LSP location at current caret
+---@param location table LSP location at current caret
 ---@param path? string path to explicitly specify the notebook
+---@param options? table Extra options; table in form {title: string}
 ---@param cb? function callback function
 ---@see https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md#zknew
-function M.link(target, location, path, cb)
-  execute_command("link", path, {path = target, location = location}, cb)
+function M.link(target, location, path, options, cb)
+  options = vim.tbl_extend("force", { path = target, location = location }, options or {})
+
+  execute_command("link", path, options, cb)
 end
 
 ---@param path? string path to explicitly specify the notebook

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -1,4 +1,5 @@
 local zk = require("zk")
+local api = require("zk.api")
 local util = require("zk.util")
 local commands = require("zk.commands")
 
@@ -69,6 +70,37 @@ commands.add("ZkLinks", function(options)
   options = vim.tbl_extend("force", { linkedBy = { vim.api.nvim_buf_get_name(0) } }, options or {})
   zk.edit(options, { title = "Zk Links" })
 end)
+
+commands.add('ZkInsertLink', function(opts)
+  opts = vim.tbl_extend("force", {}, opts or {})
+
+  local location = util.get_lsp_location_from_selection()
+  local selected_text = util.get_text_in_range(util.get_selected_range())
+
+  if not selected_text then
+    location = util.get_lsp_location_from_caret()
+  else
+    if opts['matchSelected'] then
+      opts = vim.tbl_extend("force", { match = { selected_text } }, opts or {})
+    end
+  end
+
+  zk.pick_notes(opts, { multi_select = false }, function(note)
+    assert(note ~= nil, "Picker failed before link insertion: note is nil")
+
+    local link_opts = {}
+
+    if selected_text ~= nil then
+      link_opts.title = selected_text
+    end
+
+    api.link(note.path, location, nil, link_opts, function(err, foo)
+      if not foo then
+        error(err)
+      end
+    end)
+  end)
+end, { title = 'Insert Zk link' })
 
 commands.add("ZkMatch", function(options)
   local selected_text = util.get_text_in_range(util.get_selected_range())

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -71,7 +71,7 @@ commands.add("ZkLinks", function(options)
   zk.edit(options, { title = "Zk Links" })
 end)
 
-commands.add('ZkInsertLink', function(opts)
+local function insert_link(opts)
   opts = vim.tbl_extend("force", {}, opts or {})
 
   local location = util.get_lsp_location_from_selection()
@@ -94,13 +94,17 @@ commands.add('ZkInsertLink', function(opts)
       link_opts.title = selected_text
     end
 
-    api.link(note.path, location, nil, link_opts, function(err, foo)
-      if not foo then
+    api.link(note.path, location, nil, link_opts, function(err, res)
+      if not res then
         error(err)
       end
     end)
   end)
-end, { title = 'Insert Zk link' })
+end
+
+commands.add('ZkInsertLink', function(opts) insert_link(opts) end, { title = 'Insert Zk link' })
+commands.add('ZkInsertLinkAtSelection', function(opts) insert_link(opts) end,
+  { title = 'Insert Zk link', needs_selection = true })
 
 commands.add("ZkMatch", function(options)
   local selected_text = util.get_text_in_range(util.get_selected_range())

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -71,13 +71,13 @@ commands.add("ZkLinks", function(options)
   zk.edit(options, { title = "Zk Links" })
 end)
 
-local function insert_link(opts)
+local function insert_link(selected, opts)
   opts = vim.tbl_extend("force", {}, opts or {})
 
   local location = util.get_lsp_location_from_selection()
   local selected_text = util.get_text_in_range(util.get_selected_range())
 
-  if not selected_text then
+  if not selected then
     location = util.get_lsp_location_from_caret()
   else
     if opts['matchSelected'] then
@@ -90,7 +90,7 @@ local function insert_link(opts)
 
     local link_opts = {}
 
-    if selected_text ~= nil then
+    if selected and selected_text ~= nil then
       link_opts.title = selected_text
     end
 
@@ -102,8 +102,8 @@ local function insert_link(opts)
   end)
 end
 
-commands.add('ZkInsertLink', function(opts) insert_link(opts) end, { title = 'Insert Zk link' })
-commands.add('ZkInsertLinkAtSelection', function(opts) insert_link(opts) end,
+commands.add('ZkInsertLink', function(opts) insert_link(false, opts) end, { title = 'Insert Zk link' })
+commands.add('ZkInsertLinkAtSelection', function(opts) insert_link(true, opts) end,
   { title = 'Insert Zk link', needs_selection = true })
 
 commands.add("ZkMatch", function(options)


### PR DESCRIPTION
Adding support for mickael-menu/zk#284

"zk.link" performs the file linking operation that `insertLinkAtLocation` does in "zk.new" but without creating a new note. This allows users to create new linking capabilities, such as using match to find related notes and creating a link from the found note.

This PR also adds two commands: 

- `ZkInsertLink`
- `ZkInsertLinkAtSelection`

Both use the note picker of choice to query all notes to find the desired note to create a link (solves #95)