### PR TITLE
Use already attached externally setup lsp client if available

### DIFF
--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -4,8 +4,34 @@ local client_id = nil
 
 local M = {}
 
+---Tries to find a client by name
+function M.external_client()
+  local client_name = config.options.lsp.config.name
+  if not client_name then
+    client_name = "zk"
+  end
+
+  local active_clients = vim.lsp.get_active_clients({name=client_name})
+
+  if active_clients == {} then
+    return nil
+  end
+
+  -- return first lsp server that is actually in use
+  for _,v in ipairs(active_clients) do
+      if v.attached_buffers ~= {} then
+        return v.id
+      end
+    end
+end
+
+
 ---Starts an LSP client if necessary
 function M.start()
+  if not client_id then
+    client_id = M.external_client()
+  end
+
   if not client_id then
     client_id = vim.lsp.start_client(config.options.lsp.config)
   end


### PR DESCRIPTION
Hi @mickael-menu,

I have prepared a solution for #104 and more generally a situation when zk lsp is set up outside `zk-nvim` (e.g. through lsp config).

The reason for going this route is connected with the builtin `zk lsp` setup seems to be broken for Windows (that I know is not supported officially). I think that because of improper path handling the root_dir is not found. [`lsp config`](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/zk.lua#L7) is using their own util function to find a dir with .zk directory, that seems to do the trick.

I think that having an option to use externally started server is still a feature worth to have. In case multiple zk-lsp servers are started and successfully attached to any buffer, the first one found by name is used. If none are found, zk-nvim starts its own and it takes the precedence from then on.



