### PR TITLE
fix(commands): remove user command creation and deletion wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Neovim extension for the [`zk`](https://github.com/mickael-menu/zk) plain text n
 
 ## Requirements
 
-* Neovim >= 0.6.0
-* `zk` >= 0.9.0
+| `zk-nvim` | `zk`   | Neovim |
+|-----------|--------|--------|
+| latest    | 0.13.0 | 0.8.0  |
 
 ## Installation
 

--- a/lua/zk/commands/init.lua
+++ b/lua/zk/commands/init.lua
@@ -2,45 +2,14 @@ local M = {}
 
 local name_fn_map = {}
 
--- NOTE: remove this once `vim.api.nvim_add_user_command` is officially released
-M._name_command_map = {}
-
--- NOTE: remove this helper once `vim.api.nvim_add_user_command` is officially released
-local function nvim_add_user_command(name, command, opts)
-  if vim.api.nvim_add_user_command then
-    vim.api.nvim_add_user_command(name, command, opts)
-  else
-    assert(type(command) == "function", "Not supported in this version of Neovim.")
-    M._name_command_map[name] = command
-    vim.cmd(table.concat({
-      "command" .. (opts.force and "!" or ""),
-      opts.range and "-range" or "",
-      opts.nargs and ("-nargs=" .. opts.nargs) or "",
-      opts.complete and ("-complete=" .. opts.complete) or "",
-      name,
-      string.format("lua require('zk.commands')._name_command_map['%s']({ args = <q-args>, range = <range> })", name),
-    }, " "))
-  end
-end
-
--- NOTE: remove this helper once `vim.api.nvim_del_user_command` is officially released
-local function nvim_del_user_command(name)
-  if vim.api.nvim_add_user_command then
-    vim.api.nvim_del_user_command(name)
-  else
-    M._name_command_map[name] = nil
-    vim.cmd("delcommand " .. name)
-  end
-end
-
----A thin wrapper around `vim.api.nvim_add_user_command` which parses the `params.args` of the command as a Lua table and passes it on to `fn`.
+---A thin wrapper around `vim.api.nvim_create_user_command` which parses the `params.args` of the command as a Lua table and passes it on to `fn`.
 ---@param name string
 ---@param fn function
 ---@param opts? table {needs_selection} makes sure the command is called with a range
----@see vim.api.nvim_add_user_command
+---@see vim.api.nvim_create_user_command
 function M.add(name, fn, opts)
   opts = opts or {}
-  nvim_add_user_command(name, function(params) -- vim.api.nvim_add_user_command
+  vim.api.nvim_create_user_command(name, function(params) -- vim.api.nvim_add_user_command
     if opts.needs_selection then
       assert(
         params.range == 2,
@@ -58,10 +27,10 @@ end
 
 ---Wrapper around `vim.api.nvim_del_user_command`
 ---@param name string
----@see vim.api.nvim_add_user_command
+---@see vim.api.nvim_del_user_command
 function M.del(name)
   name_fn_map[name] = nil
-  nvim_del_user_command(name) -- vim.api.nvim_del_user_command
+  vim.api.nvim_del_user_command(name)
 end
 
 return M


### PR DESCRIPTION
Removed user command helpers, as `nvim_create_user_command` and `nvim_del_user_command` are officially released.

Fix #114 