### PR TITLE
Added support for fzf-lua as a picker

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -85,7 +85,7 @@ local function insert_link(selected, opts)
     end
   end
 
-  zk.pick_notes(opts, { multi_select = false }, function(note)
+  zk.pick_notes(opts, { title = "Zk Insert link", multi_select = false }, function(note)
     assert(note ~= nil, "Picker failed before link insertion: note is nil")
 
     local link_opts = {}

--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -28,7 +28,7 @@ end
 
 M.note_picker_list_api_selection = { "title", "absPath", "path" }
 
-function M.show_note_picker(notes, options, cb)
+function M.show_note_picker(notes, options)
     options = options or {}
     local fzf_opts = vim.tbl_extend("force", {
         prompt = options.title .. "> ",
@@ -39,6 +39,9 @@ function M.show_note_picker(notes, options, cb)
             ["--with-nth"] = 2,
             ["--tabstop"] = 4,
         },
+        -- we rely on `fzf-lua` to open notes from selections to take advantage of the plugin builtin
+        -- actions configured before, which clash/act weird if we use them while using `zk-nvim`
+        -- callback
         actions = {
             ["default"] = function(selected, opts)
                 local entries = path_from_selected(selected)
@@ -58,18 +61,14 @@ function M.show_note_picker(notes, options, cb)
             end,
         },
     }, options.fzf_lua or {})
-
     exec(function(fzf_cb)
         for _, note in ipairs(notes) do
             local title = note.title or note.path
             local entry = table.concat({ note.absPath, title }, delimiter)
-            notes_by_path[note.absPath] = note
             fzf_cb(entry)
         end
         fzf_cb() --EOF
     end, fzf_opts)
-
-    -- exec(notes, fzf_opts)
 end
 
 function M.show_tag_picker(tags, options, cb)

--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -1,0 +1,122 @@
+local exec = require("fzf-lua").fzf_exec
+local builtin_previewer = require("fzf-lua.previewer.builtin")
+local ansi_codes = require("fzf-lua").utils.ansi_codes
+local actions = require("fzf-lua").actions
+
+local M = {}
+
+local delimiter = "\x01"
+
+local fzf_lua_previewer = builtin_previewer.buffer_or_file:extend()
+
+function fzf_lua_previewer:new(o, opts, fzf_win)
+    fzf_lua_previewer.super.new(self, o, opts, fzf_win)
+    setmetatable(self, fzf_lua_previewer)
+    return self
+end
+
+function fzf_lua_previewer:parse_entry(entry)
+    local path = entry:match("([^" .. delimiter .. "]+)")
+    return { path = path, }
+end
+
+local function path_from_selected(selected)
+    return vim.tbl_map(function(line)
+        return string.match(line, "([^" .. delimiter .. "]+)")
+    end, selected)
+end
+
+M.note_picker_list_api_selection = { "title", "absPath", "path" }
+
+function M.show_note_picker(notes, options, cb)
+    options = options or {}
+    local fzf_opts = vim.tbl_extend("force", {
+        prompt = options.title .. "> ",
+        previewer = fzf_lua_previewer,
+        fzf_opts = {
+            ["--delimiter"] = delimiter,
+            ["--tiebreak"] = "index",
+            ["--with-nth"] = 2,
+            ["--tabstop"] = 4,
+        },
+        actions = {
+            ["default"] = function(selected, opts)
+                local entries = path_from_selected(selected)
+                actions.file_edit(entries, opts)
+            end,
+            ["ctrl-s"] = function(selected, opts)
+                local entries = path_from_selected(selected)
+                actions.file_split(entries, opts)
+            end,
+            ["ctrl-v"] = function(selected, opts)
+                local entries = path_from_selected(selected)
+                actions.file_vsplit(entries, opts)
+            end,
+            ["ctrl-t"] = function(selected, opts)
+                local entries = path_from_selected(selected)
+                actions.file_tabedit(entries, opts)
+            end,
+        },
+    }, options.fzf_lua or {})
+
+    exec(function(fzf_cb)
+        for _, note in ipairs(notes) do
+            local title = note.title or note.path
+            local entry = table.concat({ note.absPath, title }, delimiter)
+            notes_by_path[note.absPath] = note
+            fzf_cb(entry)
+        end
+        fzf_cb() --EOF
+    end, fzf_opts)
+
+    -- exec(notes, fzf_opts)
+end
+
+function M.show_tag_picker(tags, options, cb)
+    options = options or {}
+    local tags_by_name = {}
+    local fzf_opts = vim.tbl_extend("force", {
+        prompt = options.title .. "> ",
+        fzf_opts = {
+            ["--delimiter"] = delimiter,
+            ["--tiebreak"] = "index",
+            ["--nth"] = 2,
+            ["--exact"] = "",
+            ["--tabstop"] = 4,
+        },
+        fn_selected = function(selected, _)
+            -- for some reason, fzf lua returns an empty string as the first selected line. this was
+            -- causing the tbl_map to generate a result zk-nvim can't resolve to open notes
+            table.remove(selected, 1)
+            local selected_tags = vim.tbl_map(function(line)
+                local name = string.match(line, "%d+%s+" .. delimiter .. "(.+)")
+                return tags_by_name[name]
+            end, selected)
+            if options.multi_select then
+                cb(selected_tags)
+            else
+                cb(selected_tags[1])
+            end
+        end
+    }, options.fzf_lua or {})
+
+    exec(function(fzf_cb)
+        for _, tag in ipairs(tags) do
+            -- formatting the note count to have some color, and adding a bit of space
+            local note_count = ansi_codes.bold(
+                ansi_codes.magenta(
+                    string.format("%-4d", tag.note_count)
+                )
+            )
+            local entry = table.concat({
+                note_count,
+                tag.name
+            }, delimiter)
+            tags_by_name[tag.name] = tag
+            fzf_cb(entry)
+        end
+        fzf_cb() --EOF
+    end, fzf_opts)
+end
+
+return M

--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -26,6 +26,16 @@ local function path_from_selected(selected)
     end, selected)
 end
 
+local function conflicts_with_fzf_lua(cmd_title)
+    local conflicting_cmds = {
+        "Zk Notes matching ",
+        "Zk Notes for tag(s) ",
+        "Zk Links ",
+        "Zk Backlinks "
+    }
+    return vim.tbl_contains(conflicting_cmds, cmd_title)
+end
+
 M.note_picker_list_api_selection = { "title", "absPath", "path" }
 
 function M.show_note_picker(notes, options, cb)
@@ -45,7 +55,7 @@ function M.show_note_picker(notes, options, cb)
         -- callback
         actions = {
             ["default"] = function(selected, opts)
-                if options.title == "Zk Insert link" then
+                if not conflicts_with_fzf_lua(options.title) then
                     local selected_notes = vim.tbl_map(function(line)
                         local path = string.match(line, "([^" .. delimiter .. "]+)")
                         return notes_by_path[path]

--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -31,8 +31,8 @@ M.note_picker_list_api_selection = { "title", "absPath", "path" }
 function M.show_note_picker(notes, options, cb)
     options = options or {}
     local notes_by_path = {}
-    local fzf_opts = vim.tbl_extend("force", {
-        prompt = options.title .. "> ",
+    local fzf_opts = vim.tbl_deep_extend("force", {
+        prompt = options.title .. " ❯ ",
         previewer = fzf_lua_previewer,
         fzf_opts = {
             ["--delimiter"] = delimiter,


### PR DESCRIPTION
Hi!

I moved to use [fzf-lua](https://github.com/ibhagwan/fzf-lua) and have been working these days to be able to use it with zk-nvim. While you are already supporting `fzf`, fzf-lua adds some nice goodies and this picker makes finding notes more consistent if you are a user of the plugin.

The small drawback is that is not very configurable right now, since `picker_options` is not exposed to be used with built-in commands, and this does not implement an extension like with telescope, so the picker can't be configured from `fzf-lua` options either. For that reason I've added some default actions that I think are handy, like opening selections in splits or tabs. If `picker_options` can be exposed at a later time, I can change this so people can configure mappings and other options themselves.

Take a look and let me know if this fits what you want to have in the plugin, and also if there is anything wrong I should change!

Cheers