### PR TITLE
attach current buffer once before creating autocmd for lazy loading

### DIFF
--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -15,6 +15,7 @@ local function setup_lsp_auto_attach()
   else
     trigger = "BufReadPost *"
   end
+  M._lsp_buf_auto_add(0)
   vim.api.nvim_command(string.format("autocmd %s lua require'zk'._lsp_buf_auto_add(0)", trigger))
 end
 


### PR DESCRIPTION
Using Lazy for packaging management, if `zk-nvim` is configured to be lazy loaded at some point after the current buffer's filetype is set, the current buffer wouldn't be attached to the lsp server.

For example, if I configure `zk-nvim` this way:
```
{
  "mickael-menu/zk-nvim",
  cmd = "ZkInsertLink",
  config = function()
    require("zk").setup {
      picker = "telescope"
    }
  end
}
```

Therefore using the execution of `:ZkInsertLink` as a trigger for lazy loading of `zk-nvim`, the current buffer, should it be a markdown file of interest, is not attached. I'd need to manually attach it.